### PR TITLE
Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ pkg_check_modules(adolc adolc)
 pkg_check_modules(ipopt REQUIRED ipopt)
 
 if(NOT TARGET ${adolc})
-	find_package(Python 2 REQUIRED COMPONENTS Development)
+	find_package(Python2 REQUIRED COMPONENTS Development)
 
 	message(STATUS "ADOL-C will be downloaded and added to the project...")
 	# Download and unpack adolc at configure time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ pkg_check_modules(adolc adolc)
 pkg_check_modules(ipopt REQUIRED ipopt)
 
 if(NOT TARGET ${adolc})
+	find_package(Python 2 REQUIRED COMPONENTS Development)
+
 	message(STATUS "ADOL-C will be downloaded and added to the project...")
 	# Download and unpack adolc at configure time
 	configure_file(CMakeLists-adolc.txt.in adolc-download/CMakeLists.txt)


### PR DESCRIPTION
Hello,
It seems that ADOLC requires the python2 libraries to be installed. In case ADOLC needs to be downloaded, I added a check for python2 which should assure that ADOLC will compile.

Regards

Schulz0r