### PR TITLE
PSOPT_RELEASE_STRING is now set in the CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ file(GLOB HEADER "src/*.h")
 add_library(${PROJECT_NAME} ${SRC} ${HEADER})
 target_include_directories(${PROJECT_NAME} PUBLIC src/ PRIVATE ${ipopt_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PUBLIC adolc ${ipopt_LIBRARIES} PRIVATE Eigen3::Eigen)
+add_definitions(-DPSOPT_RELEASE_STRING="${PSOPT_VERSION}")
 
 if(${BUILD_EXAMPLES})
 	add_subdirectory(examples/)

--- a/RELEASE_NUMBER
+++ b/RELEASE_NUMBER
@@ -1,4 +1,0 @@
-
-#define PSOPT_RELEASE_STRING "4.0.1"
-
-

--- a/src/psopt.h
+++ b/src/psopt.h
@@ -29,8 +29,6 @@ e-mail:    v.m.becerra@ieee.org
 
 **********************************************************************************************/
 
-#include "../../RELEASE_NUMBER"
-
 #include <Eigen/Dense>
 
 // using namespace Eigen;


### PR DESCRIPTION
Usually, it is a good idea to let CMake manage the versioning. I removed the file containing the release number. The #define for the PSOPT_RELEASE_STRING is now set in the CMakeLists.txt.