### PR TITLE
ColPack is now required to build Adol-C

### DIFF
--- a/CMakeLists-adolc.txt.in
+++ b/CMakeLists-adolc.txt.in
@@ -8,6 +8,7 @@ ExternalProject_Add(adolc
   GIT_TAG           master
   BUILD_IN_SOURCE   ON
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/adolc-src"
+  UPDATE_COMMAND    ""
   CONFIGURE_COMMAND autoreconf -fi && ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/adolc-build --enable-sparse
   BUILD_COMMAND     make -j3
   INSTALL_COMMAND   make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ pkg_check_modules(adolc adolc)
 pkg_check_modules(ipopt REQUIRED ipopt)
 
 if(NOT TARGET ${adolc})
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
+    find_package(ColPack REQUIRED)
 	find_package(Python2 REQUIRED COMPONENTS Development)
 
 	message(STATUS "ADOL-C will be downloaded and added to the project...")

--- a/cmake/FindColPack.cmake
+++ b/cmake/FindColPack.cmake
@@ -1,0 +1,29 @@
+# - Try to find ColPack
+# Once done, this will define
+#
+#  ColPack_FOUND - system has ColPack
+#  ColPack_INCLUDE_DIRS - the ColPack include directories
+#  ColPack_LIBRARIES - link these to use ColPack
+
+find_package(PkgConfig)
+pkg_check_modules(ColPack QUIET ColPack)
+
+set(ColPack_DEFINITIONS ${ColPack_CFLAGS_OTHER})
+
+find_path(ColPack_INCLUDE_DIR ColPack/ColPackHeaders.h
+          HINTS ${ColPack_INCLUDEDIR} ${ColPack_INCLUDE_DIRS}
+          PATH_SUFFIXES libxml2 )
+
+find_library(ColPack_LIBRARY NAMES ColPack
+             HINTS ${ColPack_LIBDIR} ${ColPack_LIBRARY_DIRS} )
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set ColPack_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(ColPack  DEFAULT_MSG
+                                  ColPack_LIBRARY ColPack_INCLUDE_DIR)
+
+mark_as_advanced(ColPack_INCLUDE_DIR ColPack_LIBRARY )
+
+set(ColPack_LIBRARIES ${ColPackLIBRARY} )
+set(ColPack_INCLUDE_DIRS ${ColPack_INCLUDE_DIR} )


### PR DESCRIPTION
Since the Sparse features of Adol-C are only available if ColPack is installed on the system, I added a check which makes sure that ColPack is available.
I did not automate the download of ColPack to PSOPT thou. Since ColPack ignores conventional naming for the install directories, it is not possible to pass it forward to Adol-C's configure script.