### PR TITLE
adolc causes less pain now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,38 +3,11 @@ project(PSOPT VERSION 5.00 LANGUAGES CXX)
 
 option(BUILD_EXAMPLES "Build examples from the example subdirectory." OFF)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(Eigen3 REQUIRED NO_MODULE)
+find_package(adolc REQUIRED)
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(adolc adolc)
 pkg_check_modules(ipopt REQUIRED ipopt)
-
-if(NOT TARGET ${adolc})
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
-    find_package(ColPack REQUIRED)
-	find_package(Python2 REQUIRED COMPONENTS Development)
-
-	message(STATUS "ADOL-C will be downloaded and added to the project...")
-	# Download and unpack adolc at configure time
-	configure_file(CMakeLists-adolc.txt.in adolc-download/CMakeLists.txt)
-	execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  	RESULT_VARIABLE result
-  	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/adolc-download )
-	if(result)
-	  message(FATAL_ERROR "CMake step for adolc failed: ${result}")
-	endif()
-	execute_process(COMMAND ${CMAKE_COMMAND} --build .
-	  RESULT_VARIABLE result
-	  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/adolc-download )
-	if(result)
-	  message(FATAL_ERROR "Build step for adolc failed: ${result}")
-	endif()
-
-	add_library(adolc SHARED IMPORTED)
-    target_include_directories(adolc INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/adolc-build/include/)
-	set_target_properties(adolc PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/adolc-build/lib64)
- 
-    set(CMAKE_CXX_FLAGS "-std=c++11")
-endif()
 
 file(GLOB SRC src/*.cxx)
 file(GLOB HEADER include/*.h)
@@ -47,7 +20,7 @@ PUBLIC
 PRIVATE 
     ${ipopt_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PUBLIC adolc ${ipopt_LIBRARIES} PRIVATE Eigen3::Eigen)
-add_definitions(-DPSOPT_RELEASE_STRING="${PSOPT_VERSION}")
+add_definitions(-DPSOPT_RELEASE_STRING="${PSOPT_VERSION}" -DHAVE_CSTDDEF)
 
 if(${BUILD_EXAMPLES})
 	add_subdirectory(examples/)

--- a/cmake/FindColPack.cmake
+++ b/cmake/FindColPack.cmake
@@ -11,8 +11,8 @@ pkg_check_modules(ColPack QUIET ColPack)
 set(ColPack_DEFINITIONS ${ColPack_CFLAGS_OTHER})
 
 find_path(ColPack_INCLUDE_DIR ColPack/ColPackHeaders.h
-          HINTS ${ColPack_INCLUDEDIR} ${ColPack_INCLUDE_DIRS}
-          PATH_SUFFIXES libxml2 )
+          HINTS ${ColPack_INCLUDE_DIR} ${ColPack_INCLUDE_DIRS}
+          PATH_SUFFIXES ColPack )
 
 find_library(ColPack_LIBRARY NAMES ColPack
              HINTS ${ColPack_LIBDIR} ${ColPack_LIBRARY_DIRS} )
@@ -25,5 +25,5 @@ find_package_handle_standard_args(ColPack  DEFAULT_MSG
 
 mark_as_advanced(ColPack_INCLUDE_DIR ColPack_LIBRARY )
 
-set(ColPack_LIBRARIES ${ColPackLIBRARY} )
+set(ColPack_LIBRARIES ${ColPack_LIBRARY} )
 set(ColPack_INCLUDE_DIRS ${ColPack_INCLUDE_DIR} )

--- a/cmake/Findadolc.cmake
+++ b/cmake/Findadolc.cmake
@@ -72,7 +72,6 @@ else()  # is it already installed locally by this file?
         find_package_handle_standard_args(adolc DEFAULT_MSG
                                         ${adolc_LIBRARIES} ${adolc_INCLUDE_DIRS})
     else()
-        message(STATUS "rgdfhnlldfgkj.")
         # handle the QUIETLY and REQUIRED arguments and set adolc_FOUND to TRUE
         # if all listed variables are TRUE
         find_package_handle_standard_args(adolc  DEFAULT_MSG


### PR DESCRIPTION
Hello,

I created a Findadolc.cmake file which takes care or AdolC. The download routine for AdolC has been moved there, so that the root CMakeList looks cleaner. I noticed that CMake downloads AdolC every time it is called, even if it is already available in the build directory. This caused an error and wasted time. That is now a thing of the past.

If you installed AdolC on your machine, make sure it is not installed into the <prefix>/lib64 directory as CMake expects it to be in <prefix>/lib (without 64).

Last, I added the compile definition -DHAVE_CSTDDEF because IPOPT won't work without that.