### PR TITLE
Path planner integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ file(GLOB HEADER include/*.h)
 add_library(${PROJECT_NAME} $<$<BOOL:$<TARGET_EXISTS:PSOPT_SNOPT_interface>>:$<TARGET_OBJECTS:PSOPT_SNOPT_interface>> ${SRC} ${HEADER})
 target_include_directories(${PROJECT_NAME}
 PUBLIC 
-    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include/>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 PRIVATE 
     ${ipopt_INCLUDE_DIRS})

--- a/cmake/CMakeLists-adolc.txt.in
+++ b/cmake/CMakeLists-adolc.txt.in
@@ -7,9 +7,9 @@ ExternalProject_Add(adolc
   GIT_REPOSITORY    https://github.com/coin-or/ADOL-C.git
   GIT_TAG           master
   BUILD_IN_SOURCE   ON
-  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/adolc-src"
+  SOURCE_DIR        "${CMAKE_BINARY_DIR}/adolc-src"
   UPDATE_COMMAND    ""
-  CONFIGURE_COMMAND autoreconf -fi && ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/adolc-build --enable-sparse
+  CONFIGURE_COMMAND autoreconf -fi && ./configure --prefix=${CMAKE_BINARY_DIR}/adolc-build --enable-sparse
   BUILD_COMMAND     make -j3
   INSTALL_COMMAND   make install
   TEST_COMMAND      ""

--- a/cmake/Findadolc.cmake
+++ b/cmake/Findadolc.cmake
@@ -33,7 +33,7 @@ if(${adolc_FOUND}) # if Adolc could be found by pkgconfig
 else()  # is it already installed locally by this file?
     # sometimes, AdolC will be downloaded each time the user calls cmake. prevent this by searching compiled files in the build dir
     find_path(adolc_INCLUDE_DIR adolc.h
-            HINTS ${CMAKE_BINARY_DIR}/adolc-build/include/adolc
+            HINTS ${CMAKE_BINARY_DIR}/adolc-build/include/
             NO_CMAKE_PATH)
 
     find_library(adolc_LIBRARY adolc
@@ -47,27 +47,25 @@ else()  # is it already installed locally by this file?
         find_package(Python2 REQUIRED COMPONENTS Development)
 
         # Download and unpack adolc at configure time
-        configure_file(${CMAKE_SOURCE_DIR}/cmake/CMakeLists-adolc.txt.in adolc-download/CMakeLists.txt)
+        configure_file(cmake/CMakeLists-adolc.txt.in ${CMAKE_BINARY_DIR}/adolc-download/CMakeLists.txt)
         
         execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
         RESULT_VARIABLE result
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/adolc-download )
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/adolc-download/ )
         if(result)
-        message(FATAL_ERROR "CMake step for adolc failed: ${result}")
+            message(FATAL_ERROR "CMake step for adolc failed: ${result}")
         endif()
         
         execute_process(COMMAND ${CMAKE_COMMAND} --build .
         RESULT_VARIABLE result
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/adolc-download )
         if(result)
-        message(FATAL_ERROR "Build step for adolc failed: ${result}")
+            message(FATAL_ERROR "Build step for adolc failed: ${result}")
         endif()
 
         add_library(adolc SHARED IMPORTED)
-        target_include_directories(adolc INTERFACE ${CMAKE_BINARY_DIR}/adolc-build/include/)
+        target_include_directories(adolc INTERFACE ${CMAKE_BINARY_DIR}/adolc-build/include)
         set_target_properties(adolc PROPERTIES IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/adolc-build/lib64)
-    
-        set(CMAKE_CXX_FLAGS "-std=c++11")
         
         find_package_handle_standard_args(adolc DEFAULT_MSG
                                         ${adolc_LIBRARIES} ${adolc_INCLUDE_DIRS})


### PR DESCRIPTION
Hello,
I integrated PSOPT in another project and had to fix some CMake files to make it work. Basically, there were many paths which were not valid anymore in case there was a CMakeLists.txt on a higher level which includes PSOPT as a subproject. These are now correct.
Also, there was a critical problem with AdolC's include directories in case it was already installed on disk.

Regards

Philipp