### PR TITLE
Adolc and snopt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.12)
 project(PSOPT VERSION 5.00 LANGUAGES CXX)
 
 option(BUILD_EXAMPLES "Build examples from the example subdirectory." OFF)

--- a/snopt-interface/CMakeLists.txt
+++ b/snopt-interface/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(${PROJECT_NAME}
 PUBLIC 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
     $<INSTALL_INTERFACE:include/PSOPT/snopt>)
-target_link_libraries(${PROJECT_NAME} PRIVATE gfortran ${snopt7_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PRIVATE gfortran adolc ${snopt7_LIBRARIES})
 
 if(${BUILD_EXAMPLES})
 	add_subdirectory(cppexamples/)


### PR DESCRIPTION
Fix 1: Error evaluating generator expression $<TARGET_EXISTS:PSOPT_SNOPT_interface>
TARGET_EXISTS is only available in CMake version 3.12 and later. I set the minimum requirement appropriately.

Fix 2: AdolC headers were missing in the SNOPT interface. I added AdolC to the SNOPT link libraries.