### PR TITLE
Snopt fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ add_definitions(-DPSOPT_RELEASE_STRING="${PSOPT_VERSION}" -DHAVE_CSTDDEF)
 
 if(${BUILD_EXAMPLES})
 	add_subdirectory(examples/)
+    if(${WITH_SNOPT_INTERFACE})
+        add_subdirectory(snopt-interface/cppexamples/)
+        add_subdirectory(snopt-interface/cexamples/)
+    endif()
 endif()
 
 # INSTALLING and PAKAGING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 PRIVATE 
-    ${ipopt_INCLUDE_DIRS})
+    ${ipopt_INCLUDE_DIRS}
+    ${adolc_INCLUDE_DIRS}
+)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC adolc ${ipopt_LIBRARIES} PRIVATE Eigen3::Eigen)
 add_definitions(-DPSOPT_RELEASE_STRING="${PSOPT_VERSION}" -DHAVE_CSTDDEF)

--- a/cmake/Findadolc.cmake
+++ b/cmake/Findadolc.cmake
@@ -17,7 +17,7 @@ if(${adolc_FOUND}) # if Adolc could be found by pkgconfig
     find_path(adolc_INCLUDE_DIR NAMES adolc.h
             HINTS ${adolc_INCLUDE_DIR} ${adolc_INCLUDE_DIRS}
             PATH_SUFFIXES adolc)
-
+    
     find_library(adolc_LIBRARY NAMES adolc
                 HINTS ${adolc_LIBDIR} ${adolc_LIBRARY_DIRS} )
 
@@ -29,7 +29,6 @@ if(${adolc_FOUND}) # if Adolc could be found by pkgconfig
     mark_as_advanced(adolc_INCLUDE_DIR adolc_LIBRARY )
 
     set(adolc_LIBRARIES ${adolc_LIBRARY} )
-    set(adolc_INCLUDE_DIRS ${adolc_INCLUDE_DIR} )
 else()  # is it already installed locally by this file?
     # sometimes, AdolC will be downloaded each time the user calls cmake. prevent this by searching compiled files in the build dir
     find_path(adolc_INCLUDE_DIR adolc.h
@@ -78,7 +77,6 @@ else()  # is it already installed locally by this file?
         mark_as_advanced(adolc_INCLUDE_DIR adolc_LIBRARY )
 
         set(adolc_LIBRARIES ${adolc_LIBRARY} )
-        set(adolc_INCLUDE_DIRS ${adolc_INCLUDE_DIR} )
     endif()
 endif()
 

--- a/snopt-interface/CMakeLists.txt
+++ b/snopt-interface/CMakeLists.txt
@@ -11,9 +11,4 @@ PUBLIC
     $<INSTALL_INTERFACE:include/PSOPT/snopt>)
 target_link_libraries(${PROJECT_NAME} PRIVATE gfortran ${snopt7_LIBRARIES})
 
-if(${BUILD_EXAMPLES})
-	add_subdirectory(cppexamples/)
-	add_subdirectory(cexamples/)
-endif()
-
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION "include/PSOPT/snopt")

--- a/snopt-interface/cexamples/CMakeLists.txt
+++ b/snopt-interface/cexamples/CMakeLists.txt
@@ -3,8 +3,8 @@ project(PSOPT_SNOPT_interface_C_examples LANGUAGES C)
 
 add_executable(toyB toyB.c)
 add_dependencies(toyB PSOPT_SNOPT_interface)
-target_link_libraries(toyB PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
+target_link_libraries(toyB PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
 
 add_executable(toyC toyC.c)
 add_dependencies(toyC PSOPT_SNOPT_interface)
-target_link_libraries(toyC PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
+target_link_libraries(toyC PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)

--- a/snopt-interface/cexamples/CMakeLists.txt
+++ b/snopt-interface/cexamples/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required (VERSION 3.10)
 project(PSOPT_SNOPT_interface_C_examples LANGUAGES C)
 
 add_executable(toyB toyB.c)
-add_dependencies(toyB PSOPT_SNOPT_interface)
-target_link_libraries(toyB PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
+add_dependencies(toyB PSOPT)
+target_link_libraries(toyB PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
 
 add_executable(toyC toyC.c)
-add_dependencies(toyC PSOPT_SNOPT_interface)
-target_link_libraries(toyC PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
+add_dependencies(toyC PSOPT)
+target_link_libraries(toyC PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)

--- a/snopt-interface/cppexamples/CMakeLists.txt
+++ b/snopt-interface/cppexamples/CMakeLists.txt
@@ -3,25 +3,25 @@ project(PSOPT_SNOPT_interface_CPP_examples LANGUAGES CXX)
 
 add_executable(sntoya sntoya.cpp sntoyA.hpp)
 add_dependencies(sntoya PSOPT_SNOPT_interface)
-target_link_libraries(sntoya PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
+target_link_libraries(sntoya PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
 
 add_executable(catmixa catmixa.cpp)
 add_dependencies(catmixa PSOPT_SNOPT_interface)
-target_link_libraries(catmixa PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
+target_link_libraries(catmixa PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
 
 add_executable(sntoya-jac sntoya-jac.cpp sntoyA.hpp)
 add_dependencies(sntoya-jac PSOPT_SNOPT_interface)
-target_link_libraries(sntoya-jac PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
+target_link_libraries(sntoya-jac PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
 
 add_executable(sntoya2 sntoya2.cpp sntoyA.hpp)
 add_dependencies(sntoya2 PSOPT_SNOPT_interface)
-target_link_libraries(sntoya2 PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
+target_link_libraries(sntoya2 PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
 
 add_executable(sntoyB sntoyB.cpp sntoyB.hpp)
 add_dependencies(sntoyB PSOPT_SNOPT_interface)
-target_link_libraries(sntoyB PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
+target_link_libraries(sntoyB PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
 
 add_executable(sntoyC sntoyC.cpp sntoyC.hpp)
 add_dependencies(sntoyC PSOPT_SNOPT_interface)
-target_link_libraries(sntoyC PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
+target_link_libraries(sntoyC PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
 

--- a/snopt-interface/cppexamples/CMakeLists.txt
+++ b/snopt-interface/cppexamples/CMakeLists.txt
@@ -3,25 +3,25 @@ project(PSOPT_SNOPT_interface_CPP_examples LANGUAGES CXX)
 
 add_executable(sntoya sntoya.cpp sntoyA.hpp)
 add_dependencies(sntoya PSOPT_SNOPT_interface)
-target_link_libraries(sntoya PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
+target_link_libraries(sntoya PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
 
 add_executable(catmixa catmixa.cpp)
 add_dependencies(catmixa PSOPT_SNOPT_interface)
-target_link_libraries(catmixa PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
+target_link_libraries(catmixa PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
 
 add_executable(sntoya-jac sntoya-jac.cpp sntoyA.hpp)
 add_dependencies(sntoya-jac PSOPT_SNOPT_interface)
-target_link_libraries(sntoya-jac PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
+target_link_libraries(sntoya-jac PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
 
 add_executable(sntoya2 sntoya2.cpp sntoyA.hpp)
 add_dependencies(sntoya2 PSOPT_SNOPT_interface)
-target_link_libraries(sntoya2 PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
+target_link_libraries(sntoya2 PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
 
 add_executable(sntoyB sntoyB.cpp sntoyB.hpp)
 add_dependencies(sntoyB PSOPT_SNOPT_interface)
-target_link_libraries(sntoyB PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
+target_link_libraries(sntoyB PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
 
 add_executable(sntoyC sntoyC.cpp sntoyC.hpp)
 add_dependencies(sntoyC PSOPT_SNOPT_interface)
-target_link_libraries(sntoyC PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
+target_link_libraries(sntoyC PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT)
 


### PR DESCRIPTION
Hello,

On my MacOS, adolc cannot simply be dropped into the link library list, because CMake automatically includes the wrong include directory. By explicitly adding ${ipopt_INCLUDE_DIRS} to the include directories, this problem seems to be resolved.

Since the SNOPT interface is only an object library, the examples cannot be linked against it. Thats why I fully compile PSOPT first, including the SNOPT interface, and then add the interface's examples later in the root CMake file. Now, the examples should run on MacOS.

Here is what I do to generate a Xcode file:
 cmake -DWITH_SNOPT_INTERFACE=1 -DBUILD_EXAMPLES=1 -DCMAKE_Fortran_COMPILER=gcc -G Xcode ..

AdolC still causes compilation errors because it doesn't conform to the C++ standard somewhere in the code, which Apple Clang does not seem to accept.