### PR TITLE
added test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(PSOPT VERSION 5.0.0 LANGUAGES CXX)
 
 option(BUILD_EXAMPLES "Build examples from the example subdirectory." OFF)
 option(WITH_SNOPT_INTERFACE "Build interface for the SNOPT optimizer." OFF)
+option(BUILD_TESTS "Build tests for PSOPT." OFF)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 find_package(Eigen3 REQUIRED NO_MODULE)
@@ -37,7 +38,9 @@ if(${BUILD_EXAMPLES})
 	add_subdirectory(examples/)
 endif()
 
-# set(CMAKE_CXX_FLAGS "-g")
+if(${BUILD_TESTS})
+	add_subdirectory(tests/)
+endif()
 
 
 # INSTALLING and PAKAGING

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.10)
+project(PSOPT_Tests)
+
+find_package(GTest)
+find_package(Threads REQUIRED)
+
+if(NOT ${GTest_FOUND})
+	message(STATUS "Google Test not found. It will be downloaded.")
+	# Download and unpack googletest at configure time
+	configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+	execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+	  RESULT_VARIABLE result
+	  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+	if(result)
+	  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+	endif()
+	execute_process(COMMAND ${CMAKE_COMMAND} --build .
+	  RESULT_VARIABLE result
+	  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+	if(result)
+	  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+	endif()
+	
+	add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+	  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+	  EXCLUDE_FROM_ALL)
+endif()
+		 
+file(GLOB SRC "*.cpp")
+add_executable(${PROJECT_NAME} ${SRC})
+add_dependencies(${PROJECT_NAME} PSOPT gtest)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    gtest_main
+    Threads::Threads
+    Eigen3::Eigen
+    adolc
+    PkgConfig::ipopt 
+    PSOPT
+    )
+
+if(${WITH_SNOPT_INTERFACE})
+    enable_language(Fortran)
+    target_link_libraries(${PROJECT_NAME} PRIVATE gfortran ${snopt7_LIBRARIES} PSOPT_SNOPT_interface)
+endif()
+
+enable_testing()
+add_test(test ${PROJECT_NAME})

--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+  GIT_REPOSITORY    https://github.com/google/googletest.git
+  GIT_TAG           master
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)

--- a/tests/test_something.cpp
+++ b/tests/test_something.cpp
@@ -1,0 +1,17 @@
+#include "gtest/gtest.h"
+#include <Eigen/Dense>
+#include <psopt.h>
+
+typedef Eigen::Matrix<adouble, 3, 1> Vector3ad;
+
+TEST(Utils, crossProduct) {
+    Vector3ad a, b, c;
+    a << 1, 2, 3;
+    b << 1, 5, 7;
+    
+    cross(a.data(), b.data(), c.data());
+    
+    ASSERT_EQ(c[0], -1);
+    ASSERT_EQ(c[1], -4);
+    ASSERT_EQ(c[2], 3);
+}

--- a/tests/tests_main.cpp
+++ b/tests/tests_main.cpp
@@ -1,0 +1,6 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char **argv) {
+	::testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
I added a test suite with an example test. Just run cmake with -DBUILD_TESTS=1. If you want to write tests for a specific module, create a file test_modulename.cxx in the tests/ directory. You can check my example in said directory to see how it works.
I still have to add a mechanism which excludes all tests using the SNOPT interface in case SNOPT has not been build, but I can do that later when you require that.