### PR TITLE
Fix off by one error in dual scaling

### DIFF
--- a/src/psopt.cxx
+++ b/src/psopt.cxx
@@ -611,7 +611,7 @@ string contact_notice=  "\n * The author can be contacted at his email address: 
          }
 
 
-		offset = lam_phase_offset+nstates*(norder+1);
+		offset = lam_phase_offset+1+nstates*(norder+1);
 	
 		if (   algorithm.nlp_method == "IPOPT"   ) {
 	                solution.dual.costates[i] = -solution.dual.costates[i];

--- a/src/psopt.cxx
+++ b/src/psopt.cxx
@@ -760,7 +760,7 @@ string contact_notice=  "\n * The author can be contacted at his email address: 
          if (algorithm.scaling=="automatic") {
              for (k=0;k<norder+1;k++) { //EIGEN_UPDATE: k index shifted by -1
 
-                    solution.dual.path[i].block(0,k,npath,1)  =solution.dual.path[i].block(0,k,npath,1).cwiseProduct( (*workspace->constraint_scaling).block(offset+(k-1)*npath,0,npath,1) );
+                    solution.dual.path[i].block(0,k,npath,1)  =solution.dual.path[i].block(0,k,npath,1).cwiseProduct( (*workspace->constraint_scaling).block(offset+(k)*npath,0,npath,1) );
   	         }
          }
          solution.dual.path[i] /= problem.scale.objective;


### PR DESCRIPTION
Fixes an off by one error due when indexing the scaling parameters for path constraints. 
This causes a crash when running a problem when the path constraints are a majority of the constraints.
This is not caught in the examples since the number of path constraints is less than the other constraints.